### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/computer-hardware-configuration.nix
+++ b/computer-hardware-configuration.nix
@@ -9,7 +9,7 @@
     ];
 
 
-  # https://nixos.wiki/wiki/Linux_kernel
+  # https://wiki.nixos.org/wiki/Linux_kernel
   boot.kernelPackages = pkgs.linuxPackages_6_9;
   boot.initrd.availableKernelModules = [ "nvme" "xhci_pci" "ahci" "usbhid" "usb_storage" "sd_mod"];
   boot.kernelModules = [ "kvm-amd" ];
@@ -19,7 +19,7 @@
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
-  # Use AMDGPU https://nixos.wiki/wiki/AMD_GPU
+  # Use AMDGPU https://wiki.nixos.org/wiki/AMD_GPU
   boot.initrd.kernelModules = [ "amdgpu" ];
   systemd.tmpfiles.rules = [
     "L+    /opt/rocm/hip   -    -    -     -    ${pkgs.rocmPackages.clr}"

--- a/configuration.nix
+++ b/configuration.nix
@@ -61,13 +61,13 @@
 
   # Enable the windowing system.
   programs.xwayland.enable = true;
-  # Enable sddm in Wayland and plasma6 https://nixos.wiki/wiki/KDE
+  # Enable sddm in Wayland and plasma6 https://wiki.nixos.org/wiki/KDE
   services.displayManager.sddm.enable = true;
   services.displayManager.sddm.wayland.enable = true;
   services.displayManager.sddm.theme = "catppuccin-mocha";
   services.desktopManager.plasma6.enable = true;
   services.displayManager.defaultSession = "plasma";
-  # Allow chromium/electron to use wayland - https://nixos.wiki/wiki/Wayland
+  # Allow chromium/electron to use wayland - https://wiki.nixos.org/wiki/Wayland
   environment.sessionVariables.NIXOS_OZONE_WL = "1";
   # Autologin sddm
   # https://github.com/NixOS/nixpkgs/blob/nixos-unstable/nixos/modules/services/display-managers/sddm.nix
@@ -130,7 +130,7 @@
   # services.xserver.xkb.options = "eurosign:e,caps:escape";
 
   # Enable sound.
-  # https://nixos.wiki/wiki/PipeWire
+  # https://wiki.nixos.org/wiki/PipeWire
   security.rtkit.enable = true;
   services.pipewire = {
     enable = true;
@@ -209,7 +209,7 @@
   ## Programs
 
   # global shell setup
-  # https://nixos.wiki/wiki/Tmux
+  # https://wiki.nixos.org/wiki/Tmux
   programs.tmux.enable = true;
   programs.starship.enable = true;
 

--- a/tailscale.nix
+++ b/tailscale.nix
@@ -5,7 +5,7 @@
 {
   # tailscale
   # https://github.com/tailscale/tailscale/issues/4254
-  # https://nixos.wiki/wiki/Tailscale
+  # https://wiki.nixos.org/wiki/Tailscale
   services.resolved.enable = true;
   services.tailscale.enable = true;
   services.tailscale.useRoutingFeatures = "client";

--- a/virt.nix
+++ b/virt.nix
@@ -12,7 +12,7 @@
   virtualisation.containers.enable = true;
   virtualisation.podman.enable = true;
   virtualisation.podman.defaultNetwork.settings.dns_enabled = true;
-  # Enable Docker - https://nixos.wiki/wiki/Docker
+  # Enable Docker - https://wiki.nixos.org/wiki/Docker
   virtualisation.docker.enable = true;
   virtualisation.docker.enableOnBoot = true;
   users.extraGroups.docker.members = [ "user" ];


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️